### PR TITLE
feat: preset icons custom icons preloader

### DIFF
--- a/packages/preset-icons/src/core.ts
+++ b/packages/preset-icons/src/core.ts
@@ -57,16 +57,7 @@ export function createPresetIcons(lookupIconLoader: (options: IconsOptions) => P
           return result
         },
         async iconCustomizer(collection, icon, props) {
-          const customIcon = preloader.get(collection, icon)
-          if (customIcon) {
-            const { attributes } = customIcon
-
-            if (attributes.width)
-              props.width = attributes.width
-
-            if (attributes.height)
-              props.height = attributes.height
-          }
+          preloader.assignProps(collection, icon, props)
 
           await customizations.iconCustomizer?.(collection, icon, props)
           if (unit) {

--- a/packages/preset-icons/src/custom.ts
+++ b/packages/preset-icons/src/custom.ts
@@ -1,0 +1,21 @@
+import type { IconifyIconBuildResult } from '@iconify/utils'
+import { convertParsedSVG, iconToSVG, parseSVGContent } from '@iconify/utils'
+
+export function customIconsPreloader() {
+  const results = new Map<string, IconifyIconBuildResult>()
+  return {
+    preload: (svg: string, collection: string, icon: string) => {
+      const _svg = parseSVGContent(svg)
+      if (_svg) {
+        const _icon = convertParsedSVG(_svg)
+        if (_icon) {
+          // calculates the SVG size in ratio base on 1em
+          results.set(`${collection}:${icon}`, iconToSVG(_icon))
+        }
+      }
+    },
+    get: (collection: string, icon: string) => {
+      return results.get(`${collection}:${icon}`)
+    },
+  }
+}

--- a/packages/preset-icons/src/custom.ts
+++ b/packages/preset-icons/src/custom.ts
@@ -14,8 +14,17 @@ export function customIconsPreloader() {
         }
       }
     },
-    get: (collection: string, icon: string) => {
-      return results.get(`${collection}:${icon}`)
+    assignProps: (collection: string, icon: string, props: Record<string, string>) => {
+      const customIcon = results.get(`${collection}:${icon}`)
+      if (customIcon) {
+        const { attributes } = customIcon
+
+        if (attributes.width)
+          props.width = attributes.width
+
+        if (attributes.height)
+          props.height = attributes.height
+      }
     },
   }
 }


### PR DESCRIPTION
Related #4060, #4089
Fix #4084

`getCustomIcon` in `@iconify/utils` does not call `iconToSVG` to calculate sizes in ratio so I create a `customIconsPreloader` and preload sizes when `transform` and apply the props in `iconCustomizer`.
